### PR TITLE
[Bug] Fix discussion template not inserted when opening DiscussionComposer with tags directly

### DIFF
--- a/js/src/admin/components/TagTemplateModal.js
+++ b/js/src/admin/components/TagTemplateModal.js
@@ -1,6 +1,6 @@
-import Button from "flarum/components/Button";
-import Modal from "flarum/components/Modal";
-import Stream from "flarum/utils/Stream";
+import Button from "flarum/common/components/Button";
+import Modal from "flarum/common/components/Modal";
+import Stream from "flarum/common/utils/Stream";
 
 export default class TagTemplateModal extends Modal {
   oninit(vnode) {

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -1,6 +1,6 @@
-import { extend } from "flarum/extend";
-import Model from "flarum/Model";
-import Button from "flarum/components/Button";
+import { extend } from "flarum/common/extend";
+import Model from "flarum/common/Model";
+import Button from "flarum/common/components/Button";
 import Tag from "flarum/tags/models/Tag";
 import EditTagModal from "flarum/tags/components/EditTagModal";
 import TagTemplateModal from "./components/TagTemplateModal";

--- a/js/src/forum/configureTagTemplates.js
+++ b/js/src/forum/configureTagTemplates.js
@@ -79,7 +79,7 @@ export default function configureTagTemplates() {
 
   override(ComposerState.prototype, "show", function (originalFunction) {
     if (
-      this.body.componentClass instanceof DiscussionComposer &&
+      this.body.componentClass === DiscussionComposer &&
       this.fields.content().trim() === ""
     ) {
       // Only insert template if the composer is empty

--- a/js/src/forum/configureTagTemplates.js
+++ b/js/src/forum/configureTagTemplates.js
@@ -37,6 +37,8 @@ function insertTemplate(contentOverwrite = false) {
   if (Object.keys(templateCandidates).length === 1) {
     let template = Object.values(templateCandidates)[0];
 
+    if (content === template) return;
+
     if (content === original) {
       app.composer.body.attrs.originalContent = template;
     } else {

--- a/js/src/forum/configureTagTemplates.js
+++ b/js/src/forum/configureTagTemplates.js
@@ -1,10 +1,12 @@
-import { extend } from "flarum/extend";
-import IndexPage from "flarum/components/IndexPage";
-import Model from "flarum/Model";
+import { extend, override } from "flarum/common/extend";
+import IndexPage from "flarum/forum/components/IndexPage";
+import DiscussionComposer from "flarum/forum/components/DiscussionComposer";
+import ComposerState from "flarum/forum/states/ComposerState";
+import Model from "flarum/common/Model";
 import Tag from "flarum/tags/models/Tag";
 import TagDiscussionModal from "flarum/tags/components/TagDiscussionModal";
 
-function insertTemplate() {
+function insertTemplate(contentOverwrite = false) {
   if (!app.composer.fields.tags) return;
   const original = app.composer.body.attrs.originalContent || "";
   const content = app.composer.fields.content().trim();
@@ -40,7 +42,12 @@ function insertTemplate() {
     } else {
       template = "\n\n" + template;
     }
-    app.composer.editor.insertAtCursor(template, false);
+
+    if (contentOverwrite) {
+      app.composer.fields.content(template);
+    } else {
+      app.composer.editor.insertAtCursor(template, false);
+    }
   }
 }
 
@@ -65,8 +72,32 @@ export default function configureTagTemplates() {
   });
 
   extend(TagDiscussionModal.prototype, "onremove", function () {
-    if (app.composer.fields.tags && app.composer.fields.tags.length > 0) {
+    if (app.composer.fields.tags?.length > 0) {
       insertTemplate();
     }
+  });
+
+  override(ComposerState.prototype, "show", function (originalFunction) {
+    if (
+      this.body.componentClass instanceof DiscussionComposer &&
+      this.fields.content().trim() === ""
+    ) {
+      // Only insert template if the composer is empty
+
+      if (this.fields.tags) {
+        // Insert if 1+ tags are selected
+        insertTemplate(true);
+      } else if (Array.isArray(this.fields.tags)) {
+        // Insert if no tags are selected, but tags field present
+        const noTagTemplate = app.forum.attribute(
+          "askvortsov-discussion-templates.no_tag_template"
+        );
+        if (noTagTemplate) {
+          this.fields.content(noTagTemplate);
+        }
+      }
+    }
+
+    return originalFunction();
   });
 }


### PR DESCRIPTION
For one of my client's themes, we need to add custom buttons to the side nav which open the DiscussionComposer, with tags pre-selected.

I use this function to do so:

```ts
function startDiscussionByTag(tag: any) {
  if (app.session.user) {
    app.composer.load(DiscussionComposer, { user: app.session.user });

    tag && (app.composer.fields.tags = [tag]);

    app.composer.show();
  } else {
    app.modal.show(LogInModal, {});
  }
}
```

This extension only extends the default New Discussion button click event handler, rather than any time a DiscussionComposer is opened, which is what this PR implements.

Note this PR's method does not allow us to remove the original method, since `flarum/tags` sets the tags field _after_ the composer has already been opened:

https://github.com/flarum/tags/blob/bc2b3c196b5177a7bad5c1d0b047720f86f6e5da/js/src/forum/addTagComposer.js#L18